### PR TITLE
fix(e2e): unblock playwright suite on macos CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,14 +29,14 @@ jobs:
           DISPLAY: ':99'
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
           GOOGLE_CLOUD: ${{ secrets.GOOGLE_CLOUD }}
       - name: Run API tests
         run: pnpm test:e2e:api
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
           GOOGLE_CLOUD: ${{ secrets.GOOGLE_CLOUD }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/tests/api/settings.spec.ts
+++ b/tests/api/settings.spec.ts
@@ -95,7 +95,7 @@ test.describe('Settings API', () => {
   test('POST /api/settings updates web search config', async ({ api }) => {
     await api.updateSettings({
       webSearch: {
-        perplexityApiKey: process.env.PERPLEXITY_API_KEY,
+        braveApiKey: process.env.BRAVE_API_KEY,
         maxResults: 10,
         recencyFilter: 'week'
       }
@@ -103,7 +103,7 @@ test.describe('Settings API', () => {
 
     const { data } = await api.getSettings()
     const ws = data.webSearch as Record<string, unknown>
-    expect(ws.perplexityApiKey).toBe(process.env.PERPLEXITY_API_KEY)
+    expect(ws.braveApiKey).toBe(process.env.BRAVE_API_KEY)
     expect(ws.maxResults).toBe(10)
   })
 

--- a/tests/e2e/app-launch.spec.ts
+++ b/tests/e2e/app-launch.spec.ts
@@ -19,7 +19,13 @@ test.describe('App Launch', () => {
     expect(isVisible).toBe(true)
   })
 
-  test('window has correct minimum dimensions', async ({ electronApp }) => {
+  test('window has correct minimum dimensions', async ({
+    electronApp,
+    mainWindow: _mainWindow
+  }) => {
+    // Depending on `mainWindow` ensures `firstWindow()` has resolved before we
+    // ask the main process for the BrowserWindow list — otherwise on a slow
+    // CI runner getAllWindows() can return [] and `size` lands undefined.
     const size = await electronApp.evaluate(({ BrowserWindow }) => {
       const win = BrowserWindow.getAllWindows()[0]
       return win?.getSize()

--- a/tests/e2e/chat-e2e.spec.ts
+++ b/tests/e2e/chat-e2e.spec.ts
@@ -7,8 +7,12 @@ import { electronTest as test, expect } from '../fixtures/electron'
 import { injectOpenAiProvider } from '../helpers/settings-inject'
 
 test.describe('Chat E2E', () => {
-  test.beforeAll(async () => {
-    // Inject settings via API before UI tests
+  // beforeEach (not beforeAll) so it runs AFTER the per-test electronApp /
+  // mainWindow fixtures — beforeAll runs before any test fixture is set up,
+  // so the Hono server on localhost:60223 doesn't exist yet and the inject
+  // fetch fails with "fetch failed". Pulling in `mainWindow` here forces the
+  // Electron app to be up before we hit its API.
+  test.beforeEach(async ({ mainWindow: _mw }) => {
     const api = new ApiClient()
     await injectOpenAiProvider(api)
   })

--- a/tests/e2e/chat-management.spec.ts
+++ b/tests/e2e/chat-management.spec.ts
@@ -10,12 +10,16 @@ test.describe('Chat Management E2E', () => {
   const api = new ApiClient()
   const testChatIds: string[] = []
 
-  test.beforeAll(async () => {
+  // See chat-e2e.spec.ts: beforeAll runs before fixtures, so the Hono server
+  // doesn't exist yet and the inject fetch errors out. beforeEach with
+  // `mainWindow` forces the Electron app up first, then idempotently
+  // re-injects the provider config.
+  test.beforeEach(async ({ mainWindow: _mw }) => {
     await injectOpenAiProvider(api)
   })
 
-  test.afterAll(async () => {
-    for (const id of testChatIds) {
+  test.afterEach(async () => {
+    for (const id of testChatIds.splice(0)) {
       await api.deleteChat(id).catch(() => {})
     }
   })

--- a/tests/e2e/settings-e2e.spec.ts
+++ b/tests/e2e/settings-e2e.spec.ts
@@ -43,7 +43,9 @@ test.describe('Settings E2E', () => {
 
       const res = await fetch('http://localhost:60223/api/settings')
       const json = await res.json()
-      return json.data.colorTone
+      // successResponse(c, settings) returns the settings object directly —
+      // no { data: ... } wrapper.
+      return json.colorTone
     })
 
     expect(response).toBe('violet')

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -5,7 +5,12 @@ import { electronTest as test, expect } from '../fixtures/electron'
 
 test.describe('Sidebar', () => {
   test('sidebar is visible on launch', async ({ mainWindow }) => {
-    const sidebar = mainWindow.locator('[data-testid="sidebar"], nav, aside')
+    // shadcn's <Sidebar /> tags its root with data-slot="sidebar" rather than
+    // rendering a <nav> / <aside>; match that first, fall back to the older
+    // selectors for any plain-HTML sidebar.
+    const sidebar = mainWindow.locator(
+      '[data-slot="sidebar"], [data-testid="sidebar"], nav, aside'
+    )
     await sidebar.first().waitFor({ state: 'visible', timeout: 10_000 })
     expect(await sidebar.first().isVisible()).toBe(true)
   })

--- a/tests/helpers/settings-inject.ts
+++ b/tests/helpers/settings-inject.ts
@@ -14,7 +14,7 @@ export async function injectApiKeys(api: ApiClient) {
       googleGeminiApiKey: process.env.GOOGLE_CLOUD ?? null
     },
     webSearch: {
-      perplexityApiKey: process.env.PERPLEXITY_API_KEY ?? null
+      braveApiKey: process.env.BRAVE_API_KEY ?? null
     }
   })
 }


### PR DESCRIPTION
Five distinct bugs surfaced once CI hit macos runners + the Brave migration:

- app-launch › "window has correct minimum dimensions": test only depended on \`electronApp\`, skipping the \`firstWindow()\` wait baked into \`mainWindow\`, so on a slow runner BrowserWindow.getAllWindows()[0] was empty and getSize() landed undefined. Pull \`mainWindow\` into the test fixtures so the window exists by the time we ask for it.
- chat-e2e + chat-management: \`beforeAll\` ran injectOpenAiProvider via fetch(localhost:60223), but Playwright fixtures haven't booted the Electron app yet at beforeAll time → "fetch failed". Switch to beforeEach with a \`mainWindow\` dep so the Hono server is up before the inject; chat-management's afterAll → afterEach for the same reason.
- settings-e2e › "color tone can be changed": read \`json.data.colorTone\`, but successResponse(c, settings) returns the settings object directly with no { data } wrapper. Drop the .data hop.
- sidebar › "sidebar is visible on launch": locator was \`[data-testid="sidebar"], nav, aside\`, none of which match shadcn's Sidebar — its root carries data-slot="sidebar". Match that first.
- settings-inject + tests/api/settings + playwright.yml: stale references to perplexityApiKey / PERPLEXITY_API_KEY left over from the Perplexity → Brave migration. Rename to braveApiKey / BRAVE_API_KEY (CI secret must also be renamed in repo settings before this passes).

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/YanceyOfficial/exodus/blob/master/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/YanceyOfficial/exodus/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [Angular Team's Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
